### PR TITLE
Update basic_info to public_profile in ios

### DIFF
--- a/src/ios/CordovaFacebook.m
+++ b/src/ios/CordovaFacebook.m
@@ -232,7 +232,7 @@ static NSMutableArray *publishPermissions;
     if (FBSession.activeSession.state == FBSessionStateCreatedTokenLoaded) {
         
         // If there's one, just open the session silently, without showing the user the login UI
-        [FBSession openActiveSessionWithReadPermissions:@[@"basic_info"]
+        [FBSession openActiveSessionWithReadPermissions:@[@"public_profile"]
                                            allowLoginUI:NO
                                       completionHandler:^(FBSession *session, FBSessionState state, NSError *error) {
                                           // Handler for session state changes


### PR DESCRIPTION
To get cached sessions working again. New FBSDK wants you to request public_profile instead of basic_info.
